### PR TITLE
chore: stop committing package.json and dist back to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,6 @@ jobs:
       - run: yarn install
       - run: yarn build
       - run: yarn test
+      - uses: freckle/check-git-clean-action@v1
+        with:
+          hint: "Run yarn build to update your dist/"

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -10,12 +10,6 @@ plugins:
   - - '@semantic-release/exec'
     - prepareCmd: 'yarn install && yarn run build'
 
-  - - '@semantic-release/git'
-    - assets:
-        - 'dist/**'
-        - 'package.json' # commit updated version back to source
-      message: 'chore(release): update dist and package.json'
-
   - '@semantic-release/npm'
 
 branches:


### PR DESCRIPTION
`.releaserc.yaml` drops `@semantic-release/git`. `ci.yml` adds [freckle/check-git-clean-action](https://github.com/freckle/check-git-clean-action)`@v1` after the build.

## Why drop the push-back

`@semantic-release/git` commits `dist/` and `package.json` back to `main`. The `main` ruleset forbids that: its only bypass actor is Renovate, and the release job authenticates as `${{ github.token }}`.

It hasn't failed here because `@semantic-release/git` is listed before `@semantic-release/npm`. It runs before the version bump, finds nothing to commit, and skips the push. So `main`'s `package.json` version trails the published one, and no `chore(release)` commit has ever landed. `maybe-js` had the same config until its plugin order was fixed, which turned the no-op into a `GH013` failure on every release.

The [Semantic Release](https://illuminate.atlassian.net/wiki/spaces/PENG/pages/17952735277/Semantic+Release) page's comment thread (2026-04-27/28) concluded that npm packages should drop the commit-back rather than fix the ordering. The push-back is needed only for GitHub Actions shipping `dist/`, apps with a compiled-in `--version`, and source installs.

## What replaces it

The push-back kept the committed `dist/` in step with source. That check moves to PR time.

The action uses `git status --porcelain`, which catches untracked files, deletions, mode changes and type changes. A `git diff`-based script misses untracked files, so a build emitting a new artifact passes it.

The action also assigns `git status` output before the `if`: under `set -e`, a git that fails inside an `if` condition contributes empty output and reads as a clean tree. It passes `--untracked-files=normal`, so a caller with `status.showUntrackedFiles=no` still gets the untracked case.

## Verification

Tried first on freckle/ajax-js#200: the action resolved `@v1` to `0141bda`, received the hint, ran, and logged `Working tree is clean.` This PR's `build` check runs it against this repo's committed artifacts.

Draft until the set is reviewed.